### PR TITLE
remove pytest-mock

### DIFF
--- a/graphene/utils/tests/test_deprecated.py
+++ b/graphene/utils/tests/test_deprecated.py
@@ -5,8 +5,8 @@ from ..deprecated import deprecated as deprecated_decorator
 from ..deprecated import warn_deprecation
 
 
-def test_warn_deprecation(mocker):
-    mocker.patch.object(deprecated.warnings, "warn")
+def test_warn_deprecation(monkeypatch):
+    monkeypatch.setattr(deprecated.warnings, "warn") 
 
     warn_deprecation("OH!")
     deprecated.warnings.warn.assert_called_with(


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [graphql-python/graphene#1558](https://togithub.com/graphql-python/graphene/pull/1558).



The original branch is fork-1558-dulmandakh/remove-pytest-mock